### PR TITLE
Specified the UI theme used in the screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ DuoTone themes use only 2 hues (8 shades in total). It __tones down__ less impor
   src="https://cloud.githubusercontent.com/assets/378023/6996874/aee76b40-dbdd-11e4-95e1-a40258a50c26.png"
   srcset="https://cloud.githubusercontent.com/assets/378023/6996875/b2160e02-dbdd-11e4-913e-7dc006437d94.png 1560w">
 
+> The UI theme used in the screenshots is [One Dark](https://atom.io/themes/one-dark-ui), which comes bundled with Atom.
 
 ## Language support
 


### PR DESCRIPTION
It seems the UI theme used in the screenshots of the code is One Dark; I specified that in a caption after the screenshots, just for the benefit of people wanting to recreate the look of this theme and to whom it wasn't obvious that the UI theme was One Dark (like me).
(I know this theme is deprecated but no harm in adding extra documentation to preserve it for future users who still wanna use it)